### PR TITLE
[bug fix]fix useSmart is unthreadsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 
+# IDEA artifacts and output dirs
+.idea
+*.iml

--- a/src/main/java/org/wltea/analyzer/cfg/Configuration.java
+++ b/src/main/java/org/wltea/analyzer/cfg/Configuration.java
@@ -34,22 +34,6 @@ import java.util.List;
 public interface Configuration {
 
     /**
-     * 返回useSmart标志位
-     * useSmart =true ，分词器使用智能切分策略， =false则使用细粒度切分
-     * 
-     * @return useSmart
-     */
-    public boolean useSmart();
-
-    /**
-     * 设置useSmart标志位
-     * useSmart =true ，分词器使用智能切分策略， =false则使用细粒度切分
-     * 
-     * @param useSmart
-     */
-    public void setUseSmart(boolean useSmart);
-
-    /**
      * 获取主词典路径
      * 
      * @return String 主词典路径

--- a/src/main/java/org/wltea/analyzer/cfg/DefaultConfig.java
+++ b/src/main/java/org/wltea/analyzer/cfg/DefaultConfig.java
@@ -55,10 +55,6 @@ public class DefaultConfig implements Configuration {
     private static final String EXT_STOP = "ext_stopwords";
 
     private Properties props;
-    /*
-     * 是否使用smart方式分词
-     */
-    private boolean useSmart;
 
     private static final DefaultConfig singleton = new DefaultConfig();
 
@@ -81,34 +77,10 @@ public class DefaultConfig implements Configuration {
         if (input != null) {
             try {
                 props.loadFromXML(input);
-            } catch (InvalidPropertiesFormatException e) {
-                e.printStackTrace();
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
-    }
-
-    /**
-     * 返回useSmart标志位
-     * useSmart =true ，分词器使用智能切分策略， =false则使用细粒度切分
-     * 
-     * @return useSmart
-     */
-    @Override
-    public boolean useSmart() {
-        return useSmart;
-    }
-
-    /**
-     * 设置useSmart标志位
-     * useSmart =true ，分词器使用智能切分策略， =false则使用细粒度切分
-     * 
-     * @param useSmart
-     */
-    @Override
-    public void setUseSmart(boolean useSmart) {
-        this.useSmart = useSmart;
     }
 
     /**
@@ -143,7 +115,7 @@ public class DefaultConfig implements Configuration {
         if (extDictCfg != null) {
             // 使用;分割多个扩展字典配置
             String[] filePaths = extDictCfg.split(";");
-            if (filePaths != null) {
+            if (filePaths.length > 0) {
                 for (String filePath : filePaths) {
                     if (filePath != null && !"".equals(filePath.trim())) {
                         extDictFiles.add(filePath.trim());
@@ -166,7 +138,7 @@ public class DefaultConfig implements Configuration {
         if (extStopWordDictCfg != null) {
             // 使用;分割多个扩展字典配置
             String[] filePaths = extStopWordDictCfg.split(";");
-            if (filePaths != null) {
+            if (filePaths.length > 0) {
                 for (String filePath : filePaths) {
                     if (filePath != null && !"".equals(filePath.trim())) {
                         extStopWordDictFiles.add(filePath.trim());

--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -317,12 +317,14 @@ class AnalyzeContext {
      * 
      * @return
      */
-    Lexeme getNextLexeme() {
+    Lexeme getNextLexeme(boolean useSmart) {
         // 从结果集取出，并移除第一个Lexme
         Lexeme result = this.results.pollFirst();
         while (result != null) {
             // 数量词合并
-            this.compound(result);
+            if (useSmart) {
+                this.compound(result);
+            }
             if (Dictionary.getSingleton().isStopWord(this.segmentBuff, result.getBegin(), result.getLength())) {
                 // 是停止词继续取列表的下一个
                 result = this.results.pollFirst();
@@ -354,9 +356,6 @@ class AnalyzeContext {
      * 组合词元
      */
     private void compound(Lexeme result) {
-        if (!this.cfg.useSmart()) {
-            return;
-        }
         // 数量词合并处理
         if (!this.results.isEmpty()) {
 

--- a/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
@@ -48,6 +48,8 @@ public final class IKSegmenter {
     private List<ISegmenter> segmenters;
     // 分词歧义裁决器
     private IKArbitrator arbitrator;
+    //useSmart =true ，分词器使用智能切分策略， =false则使用细粒度切分
+    private boolean useSmart;
 
     /**
      * IK分词器构造函数
@@ -61,7 +63,7 @@ public final class IKSegmenter {
     public IKSegmenter(Reader input, boolean useSmart) {
         this.input = input;
         this.cfg = DefaultConfig.getInstance();
-        this.cfg.setUseSmart(useSmart);
+        this.useSmart = useSmart;
         this.init();
     }
 
@@ -116,7 +118,7 @@ public final class IKSegmenter {
      */
     public synchronized Lexeme next() throws IOException {
         Lexeme l = null;
-        while ((l = context.getNextLexeme()) == null) {
+        while ((l = context.getNextLexeme(this.useSmart)) == null) {
             /*
              * 从reader中读取数据，填充buffer
              * 如果reader是分次读入buffer的，那么buffer要 进行移位处理
@@ -148,7 +150,7 @@ public final class IKSegmenter {
                 }
             }
             // 对分词进行歧义处理
-            this.arbitrator.process(context, this.cfg.useSmart());
+            this.arbitrator.process(context, this.useSmart);
             // 将分词结果输出到结果集，并处理未切分的单个CJK字符
             context.outputToResult();
             // 记录本次分词的缓冲区位移


### PR DESCRIPTION
解决的问题:
   原先useSmart用作是否使用智能分词的标识，被DefaultConfig管理，而DefaultConfig作为单例，会导致useSmart是线程不安全的。

改动:
   将useSmart移到IKSegmenter分词类中管理

